### PR TITLE
Use JSON Web Tokens

### DIFF
--- a/models/member.js
+++ b/models/member.js
@@ -298,6 +298,22 @@ class Member {
   }
 
   /**
+   * Convenience function that gets the Member ID from the JSON Web Token and
+   * passes it to Member.load, allowing you to get a Member instance directly
+   * from a JSON Web Token.
+   * @param token {string} - A JSON Web Token.
+   * @param db {Pool} - The database connection.
+   * @returns {Promise<Member|undefined>} - A Promise that resolves either with
+   *   the Member instance of the logged in member if the JSON Web Token can be
+   *   verified and matched, or `undefined` if it could not be.
+   */
+
+  static async loadFromJWT (token, db) {
+    const payload = await jwt.verify(token, config.jwt.secret)
+    return payload && payload.id ? Member.load(payload.id, db) : null
+  }
+
+  /**
    * Checks if a member with the given email and password exists. If she does,
    * it returns her ID. If not — either because the email is not associated
    * with any member account, or it is associated with a member account but the

--- a/models/member.js
+++ b/models/member.js
@@ -246,6 +246,20 @@ class Member {
   }
 
   /**
+   * Return an object representing the member's data, sans private attributes
+   * like password, email, number of invitations, and active status.
+   * @returns {Object} - An object representing the member's data, sans private
+   *   attributes like password and email.
+   */
+
+  privatize () {
+    const cpy = JSON.parse(JSON.stringify(this))
+    const priv = [ 'password', 'email', 'invitations', 'active' ]
+    priv.forEach(key => { delete cpy[key] })
+    return cpy
+  }
+
+  /**
    * Load a Member instance from the database.
    * @param id {!number|string} - Either the primary key or the email address of
    *   the member to load.

--- a/models/member.js
+++ b/models/member.js
@@ -1,5 +1,7 @@
 const bcrypt = require('bcrypt')
 const { escape } = require('sqlstring')
+const jwt = require('jsonwebtoken')
+const config = require('../config')
 
 class Member {
   constructor (obj) {
@@ -257,6 +259,20 @@ class Member {
     const priv = [ 'password', 'email', 'invitations', 'active' ]
     priv.forEach(key => { delete cpy[key] })
     return cpy
+  }
+
+  /**
+   * Generate a new JSON Web Token for the user.
+   * @returns {undefined|*}
+   */
+
+  generateJWT () {
+    const options = {
+      expiresIn: '1800s',
+      issuer: config.jwt.domain,
+      subject: `${config.jwt.domain}/members/${this.id}`
+    }
+    return jwt.sign(this.privatize(), config.jwt.secret, options)
   }
 
   /**

--- a/models/member.js
+++ b/models/member.js
@@ -268,7 +268,7 @@ class Member {
 
   generateJWT () {
     const options = {
-      expiresIn: '1800s',
+      expiresIn: '900s',
       issuer: config.jwt.domain,
       subject: `${config.jwt.domain}/members/${this.id}`
     }

--- a/models/member.spec.js
+++ b/models/member.spec.js
@@ -621,6 +621,22 @@ describe('Member', () => {
     })
   })
 
+  describe('privatize', () => {
+    it('returns an object without private fields', async () => {
+      expect.assertions(6)
+      await testUtils.populateMembers(db)
+      const member = await Member.load(2, db)
+      const actual = await member.privatize(db)
+      await testUtils.resetTables(db)
+      expect(typeof actual).toEqual('object')
+      expect(actual.id).toBeDefined()
+      expect(actual.email).not.toBeDefined()
+      expect(actual.password).not.toBeDefined()
+      expect(actual.invitations).not.toBeDefined()
+      expect(actual.active).not.toBeDefined()
+    })
+  })
+
   describe('load', () => {
     it('loads an instance from the database', async () => {
       expect.assertions(4)

--- a/models/member.spec.js
+++ b/models/member.spec.js
@@ -2,7 +2,9 @@
 
 const bcrypt = require('bcrypt')
 const { escape } = require('sqlstring')
+const jwt = require('jsonwebtoken')
 const db = require('../db')
+const config = require('../config')
 const testUtils = require('../test-utils')
 
 const Member = require('./member')
@@ -634,6 +636,23 @@ describe('Member', () => {
       expect(actual.password).not.toBeDefined()
       expect(actual.invitations).not.toBeDefined()
       expect(actual.active).not.toBeDefined()
+    })
+  })
+
+  describe('generateJWT', () => {
+    it('returns a JSON Web Token', async () => {
+      expect.assertions(6)
+      await testUtils.populateMembers(db)
+      const member = await Member.load(2, db)
+      const token = await member.generateJWT()
+      const actual = await jwt.verify(token, config.jwt.secret)
+      await testUtils.resetTables(db)
+      expect(actual).toBeDefined()
+      expect(actual.id).toEqual(2)
+      expect(actual.name).toEqual('Normal')
+      expect(actual.admin).toEqual(false)
+      expect(actual.iss).toEqual(config.jwt.domain)
+      expect(actual.sub).toEqual(`${config.jwt.domain}/members/2`)
     })
   })
 

--- a/models/member.spec.js
+++ b/models/member.spec.js
@@ -680,6 +680,21 @@ describe('Member', () => {
     })
   })
 
+  describe('loadFromJWT', () => {
+    it('loads a Member instance from a JSON Web Token', async () => {
+      expect.assertions(4)
+      await testUtils.populateMembers(db)
+      const member = await Member.load('admin@thefifthworld.com', db)
+      const token = member.generateJWT()
+      const actual = await Member.loadFromJWT(token, db)
+      await testUtils.resetTables(db)
+      expect(actual.id).toEqual(member.id)
+      expect(actual.name).toEqual(member.name)
+      expect(actual.email).toEqual(member.email)
+      expect(actual.admin).toEqual(actual.admin)
+    })
+  })
+
   describe('authenticate', () => {
     it('resolves with false if the email is not associated with a record', async () => {
       expect.assertions(1)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1212,6 +1212,11 @@
         "isarray": "^1.0.0"
       }
     },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+    },
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
@@ -1757,6 +1762,14 @@
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
+      }
+    },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "ee-first": {
@@ -4112,6 +4125,30 @@
         "minimist": "^1.2.5"
       }
     },
+    "jsonwebtoken": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+      "requires": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -4122,6 +4159,25 @@
         "extsprintf": "1.3.0",
         "json-schema": "0.2.3",
         "verror": "1.10.0"
+      }
+    },
+    "jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "requires": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "kind-of": {
@@ -4184,6 +4240,41 @@
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+    },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
+    "lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+    },
+    "lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+    },
+    "lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
+    "lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
     "lodash.sortby": {
       "version": "4.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1068,14 +1068,6 @@
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
       "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
     },
-    "basic-auth": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
-      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
-      "requires": {
-        "safe-buffer": "5.1.2"
-      }
-    },
     "bcrypt": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-4.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "express": "^4.17.1",
     "express-fileupload": "^1.1.7-alpha.3",
     "image-thumbnail": "^1.0.8",
+    "jsonwebtoken": "^8.5.1",
     "mailgun-js": "^0.22.0",
     "md5": "^2.2.1",
     "mysql": "^2.18.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   "main": "index.js",
   "dependencies": {
     "aws-sdk": "^2.658.0",
-    "basic-auth": "^2.0.1",
     "bcrypt": "^4.0.1",
     "body-parser": "^1.19.0",
     "express": "^4.17.1",

--- a/routes/members.js
+++ b/routes/members.js
@@ -21,6 +21,11 @@ members.post('/members/auth', async (req, res) => {
   }
 })
 
+// POST /members/reauth
+members.post('/members/reauth', requireLogIn, async (req, res) => {
+  res.status(200).send(req.user.generateJWT())
+})
+
 // GET /members/:id
 members.get('/members/:id', async (req, res) => {
   const id = parseInt(req.params.id)

--- a/routes/members.js
+++ b/routes/members.js
@@ -5,6 +5,22 @@ const sendEmail = require('../emailer')
 const db = require('../db')
 const members = express.Router()
 
+// POST /members/auth
+members.post('/members/auth', async (req, res) => {
+  if (req.body) {
+    const { email, pass } = req.body
+    const id = email && pass
+      ? await Member.authenticate(email, pass, db)
+      : false
+    const member = id ? await Member.load(id, db) : false
+    if (member) {
+      res.status(200).send(member.generateJWT())
+    } else {
+      res.sendStatus(401)
+    }
+  }
+})
+
 // GET /members/:id
 members.get('/members/:id', async (req, res) => {
   const id = parseInt(req.params.id)

--- a/routes/members.js
+++ b/routes/members.js
@@ -5,26 +5,12 @@ const sendEmail = require('../emailer')
 const db = require('../db')
 const members = express.Router()
 
-/**
- * Strip sensitive information from a Member instance.
- * @param member {Member} - A Member instance to privatize.
- * @returns {Object} - A copy of the Member instance with private information
- *   stripped out.
- */
-
-const privatize = member => {
-  const cpy = JSON.parse(JSON.stringify(member))
-  const priv = [ 'password', 'email', 'invitations', 'active' ]
-  priv.forEach(key => { delete cpy[key] })
-  return cpy
-}
-
 // GET /members/:id
 members.get('/members/:id', async (req, res) => {
   const id = parseInt(req.params.id)
   const member = id && !isNaN(id) ? await Member.load(id, db) : undefined
   if (member && member.active) {
-    res.status(200).json(privatize(member))
+    res.status(200).json(member.privatize())
   } else {
     res.status(404).json({ err: 'Member not found' })
   }
@@ -56,7 +42,7 @@ members.get('/members/:id/messages', requireLogIn, async (req, res) => {
 // GET /members/:id/invited
 members.get('/members/:id/invited', requireLogIn, async (req, res) => {
   const invited = await req.user.getInvited(db)
-  res.status(200).json(invited.map(member => privatize(member)))
+  res.status(200).json(invited.map(member => member.privatize ? member.privatize() : member))
 })
 
 // PATCH /members/:id/deactivate

--- a/routes/members.spec.js
+++ b/routes/members.spec.js
@@ -62,6 +62,21 @@ describe('Members API', () => {
     })
   })
 
+  describe('POST /members/reauth', () => {
+    it('returns a new JSON Web Token if you have an old one', async () => {
+      expect.assertions(6)
+      const init = await request.post('/members/auth').send({ email: 'normal@thefifthworld.com', pass: 'password' })
+      const res = await request.post('/members/reauth').set('Authorization', `Bearer ${init.text}`)
+      const token = await jwt.verify(res.text, config.jwt.secret)
+      expect(res.status).toEqual(200)
+      expect(token.id).toEqual(2)
+      expect(token.name).toEqual('Normal')
+      expect(token.admin).toEqual(false)
+      expect(token.iss).toEqual(config.jwt.domain)
+      expect(token.sub).toEqual(`${config.jwt.domain}/members/2`)
+    })
+  })
+
   describe('GET /members/:id', () => {
     it('returns 200', async () => {
       expect.assertions(1)

--- a/routes/members.spec.js
+++ b/routes/members.spec.js
@@ -117,22 +117,28 @@ describe('Members API', () => {
   describe('PATCH /members/:id', () => {
     it('returns 200', async () => {
       expect.assertions(1)
-      const res = await request.patch('/members/2').auth('normal@thefifthworld.com', 'password')
+      const member = await Member.load(2, db)
+      const token = member.generateJWT()
+      const res = await request.patch('/members/2').set('Authorization', `Bearer ${token}`)
       expect(res.status).toEqual(200)
     })
 
     it('updates the member\'s data', async () => {
       expect.assertions(1)
+      const member = await Member.load(2, db)
+      const token = member.generateJWT()
       const updates = { bio: 'New bio' }
-      await request.patch('/members/2').auth('normal@thefifthworld.com', 'password').send(updates)
+      await request.patch('/members/2').set('Authorization', `Bearer ${token}`).send(updates)
       const acct = await Member.load(2, db)
       expect(acct.bio).toEqual(updates.bio)
     })
 
     it('returns the member\'s data', async () => {
       expect.assertions(5)
+      const member = await Member.load(2, db)
+      const token = member.generateJWT()
       const updates = { bio: 'New bio' }
-      const res = await request.patch('/members/2').auth('normal@thefifthworld.com', 'password').send(updates)
+      const res = await request.patch('/members/2').set('Authorization', `Bearer ${token}`).send(updates)
       expect(res.body.id).toEqual(2)
       expect(res.body.email).toEqual('normal@thefifthworld.com')
       expect(res.body.active).toEqual(true)
@@ -142,13 +148,17 @@ describe('Members API', () => {
 
     it('won\'t let you update someone else\'s account', async () => {
       expect.assertions(1)
-      const res = await request.patch('/members/2').auth('other@thefifthworld.com', 'password')
+      const member = await Member.load(3, db)
+      const token = member.generateJWT()
+      const res = await request.patch('/members/2').set('Authorization', `Bearer ${token}`)
       expect(res.status).toEqual(401)
     })
 
     it('lets an admin update someone else\'s account', async () => {
       expect.assertions(1)
-      const res = await request.patch('/members/2').auth('admin@thefifthworld.com', 'password')
+      const admin = await Member.load(1, db)
+      const token = admin.generateJWT()
+      const res = await request.patch('/members/2').set('Authorization', `Bearer ${token}`)
       expect(res.status).toEqual(200)
     })
   })
@@ -165,7 +175,8 @@ describe('Members API', () => {
       const msg = 'Test message'
       const normal = await Member.load(2, db)
       await normal.logMessage('info', msg, db)
-      const res = await request.get('/members/2/messages').auth('normal@thefifthworld.com', 'password')
+      const token = normal.generateJWT()
+      const res = await request.get('/members/2/messages').set('Authorization', `Bearer ${token}`)
       expect(res.status).toEqual(200)
       expect(res.body.info).toEqual([ msg ])
     })
@@ -183,7 +194,8 @@ describe('Members API', () => {
       const normal = await Member.load(2, db)
       const emails = [ 'one@thefifthworld.com', 'two@thefifthworld.com' ]
       await normal.sendInvitations(emails, () => {}, db)
-      const res = await request.get('/members/2/invited').auth('normal@thefifthworld.com', 'password')
+      const token = normal.generateJWT()
+      const res = await request.get('/members/2/invited').set('Authorization', `Bearer ${token}`)
 
       expect(res.status).toEqual(200)
       expect(res.body).toHaveLength(2)
@@ -201,26 +213,34 @@ describe('Members API', () => {
   describe('PATCH /members/:id/deactivate', () => {
     it('returns 200', async () => {
       expect.assertions(1)
-      const res = await request.patch('/members/2/deactivate').auth('admin@thefifthworld.com', 'password')
+      const admin = await Member.load(1, db)
+      const token = admin.generateJWT()
+      const res = await request.patch('/members/2/deactivate').set('Authorization', `Bearer ${token}`)
       expect(res.status).toEqual(200)
     })
 
     it('sets the user\'s active flag to false', async () => {
       expect.assertions(1)
-      await request.patch('/members/2/deactivate').auth('admin@thefifthworld.com', 'password')
+      const admin = await Member.load(1, db)
+      const token = admin.generateJWT()
+      await request.patch('/members/2/deactivate').set('Authorization', `Bearer ${token}`)
       const acct = await Member.load(2, db)
       expect(acct.active).toEqual(false)
     })
 
     it('returns 401 if you\'re not an admin', async () => {
       expect.assertions(1)
-      const res = await request.patch('/members/2/deactivate').auth('other@thefifthworld.com', 'password')
+      const other = await Member.load(3, db)
+      const token = other.generateJWT()
+      const res = await request.patch('/members/2/deactivate').set('Authorization', `Bearer ${token}`)
       expect(res.status).toEqual(401)
     })
 
     it('returns 401 even if you try to deactivate yourself', async () => {
       expect.assertions(1)
-      const res = await request.patch('/members/2/deactivate').auth('normal@thefifthworld.com', 'password')
+      const member = await Member.load(2, db)
+      const token = member.generateJWT()
+      const res = await request.patch('/members/2/deactivate').set('Authorization', `Bearer ${token}`)
       expect(res.status).toEqual(401)
     })
   })
@@ -230,9 +250,10 @@ describe('Members API', () => {
       expect.assertions(1)
       const admin = await Member.load(1, db)
       const normal = await Member.load(2, db)
+      const token = admin.generateJWT()
       await normal.deactivate(admin, db)
 
-      const res = await request.patch('/members/2/reactivate').auth('admin@thefifthworld.com', 'password')
+      const res = await request.patch('/members/2/reactivate').set('Authorization', `Bearer ${token}`)
       expect(res.status).toEqual(200)
     })
 
@@ -240,9 +261,10 @@ describe('Members API', () => {
       expect.assertions(1)
       const admin = await Member.load(1, db)
       const normal = await Member.load(2, db)
+      const token = admin.generateJWT()
       await normal.deactivate(admin, db)
 
-      await request.patch('/members/2/reactivate').auth('admin@thefifthworld.com', 'password')
+      await request.patch('/members/2/reactivate').set('Authorization', `Bearer ${token}`)
       const acct = await Member.load(2, db)
       expect(acct.active).toEqual(true)
     })
@@ -251,9 +273,11 @@ describe('Members API', () => {
       expect.assertions(1)
       const admin = await Member.load(1, db)
       const normal = await Member.load(2, db)
+      const other = await Member.load(3, db)
+      const token = other.generateJWT()
       await normal.deactivate(admin, db)
 
-      const res = await request.patch('/members/2/reactivate').auth('other@thefifthworld.com', 'password')
+      const res = await request.patch('/members/2/reactivate').set('Authorization', `Bearer ${token}`)
       expect(res.status).toEqual(401)
     })
 
@@ -261,9 +285,10 @@ describe('Members API', () => {
       expect.assertions(1)
       const admin = await Member.load(1, db)
       const normal = await Member.load(2, db)
+      const token = normal.generateJWT()
       await normal.deactivate(admin, db)
 
-      const res = await request.patch('/members/2/reactivate').auth('normal@thefifthworld.com', 'password')
+      const res = await request.patch('/members/2/reactivate').set('Authorization', `Bearer ${token}`)
       expect(res.status).toEqual(401)
     })
   })
@@ -276,8 +301,10 @@ describe('Members API', () => {
 
     it('returns the emails you tried to invite and your messages', async () => {
       expect.assertions(3)
+      const member = await Member.load(2, db)
+      const token = member.generateJWT()
       const invites = { emails: [ 'invited1@thefifthworld.com', 'invited2@thefifthworld.com' ], test: true }
-      const res = await request.post('/invitations/send').auth('normal@thefifthworld.com', 'password').send(invites)
+      const res = await request.post('/invitations/send').set('Authorization', `Bearer ${token}`).send(invites)
       expect(res.status).toEqual(200)
       expect(res.body.emails).toEqual(invites.emails)
       expect(res.body.messages.confirmation).toHaveLength(2)

--- a/security.js
+++ b/security.js
@@ -1,4 +1,3 @@
-const basicAuth = require('basic-auth')
 const Member = require('./models/member')
 const Page = require('./models/page')
 const db = require('./db')

--- a/security.js
+++ b/security.js
@@ -1,22 +1,22 @@
+const jwt = require('jsonwebtoken')
 const Member = require('./models/member')
 const Page = require('./models/page')
 const db = require('./db')
 
 /**
- * Prompt HTTP basic authentication.
+ * Verrifies JSON Web Token.
  * @param req {!Object} - The Express.js request object.
- * @returns {Promise<boolean|number>} - A Promise that resolves with the
- *   primary key of the member if she successfully authenticated, or `false` if
- *   she did not.
+ * @returns {Promise<Member|boolean>} - A Promise that resolves with the
+ *   Member instance of the user if she has presented a valid JSON Web Token,
+ *   or `false` if she has not.
  */
 
-const promptAuth = async req => {
-  const auth = basicAuth(req)
-  if (auth && auth.name && auth.pass) {
-    return await Member.authenticate(auth.name, auth.pass, db)
-  } else {
-    return false
-  }
+const verifyJWT = async req => {
+  const {authorization} = req.headers
+  const token = authorization ? authorization.split(' ')[1] : null
+  return token
+    ? await Member.loadFromJWT(token, db)
+    : null
 }
 
 /**
@@ -31,9 +31,9 @@ const promptAuth = async req => {
  */
 
 const requireLogIn = async (req, res, next) => {
-  const id = await promptAuth(req)
-  if (id) {
-    req.user = await Member.load(id, db)
+  const member = await verifyJWT(req)
+  if (member) {
+    req.user = member
     next()
   } else {
     res.sendStatus(401)
@@ -52,8 +52,8 @@ const requireLogIn = async (req, res, next) => {
  */
 
 const optionalLogIn = async (req, res, next) => {
-  const id = await promptAuth(req)
-  if (id) req.user = await Member.load(id, db)
+  const member = await verifyJWT(req)
+  if (id) req.user = member
   next()
 }
 
@@ -79,9 +79,9 @@ const loadPage = async (req, res, next) => {
     req.page = page
     next()
   } else if (page) {
-    const id = await promptAuth(req)
-    if (id) {
-      req.user = await Member.load(id, db)
+    const member = await verifyJWT(req)
+    if (member) {
+      req.user = member
       if (page.checkPermissions(req.user, 4)) {
         req.page = page
         next()

--- a/security.js
+++ b/security.js
@@ -53,7 +53,7 @@ const requireLogIn = async (req, res, next) => {
 
 const optionalLogIn = async (req, res, next) => {
   const member = await verifyJWT(req)
-  if (id) req.user = member
+  if (member) req.user = member
   next()
 }
 


### PR DESCRIPTION
Add `POST /members/auth` so that a member who supplies the correct combination of email and pass phrase can get a JSON Web Token. Add `POST /members/reauth` so that someone who has an existing JSON Web Token can get a new one. Update our security middlewares to use JSON Web Tokens (JWT) instead of Basic Auth, and update all of our unit tests to use JWT's as well.