### PR TITLE
Better organize provider endpoints

### DIFF
--- a/routes/members.js
+++ b/routes/members.js
@@ -26,8 +26,8 @@ members.post('/members/reauth', requireLogIn, async (req, res) => {
   res.status(200).send(req.user.generateJWT())
 })
 
-// POST /members/add-auth
-members.post('/members/add-auth', requireLogIn, async (req, res) => {
+// POST /members/providers
+members.post('/members/providers', requireLogIn, async (req, res) => {
   const { provider, id, token } = req.body
   if (provider && id && token) {
     await req.user.saveAuth(provider, id, token, db)
@@ -35,6 +35,19 @@ members.post('/members/add-auth', requireLogIn, async (req, res) => {
   } else {
     res.sendStatus(406)
   }
+})
+
+// GET /members/providers
+members.get('/members/providers', requireLogIn, async (req, res) => {
+  const auths = await req.user.getAuths(db)
+  res.status(200).json(auths)
+})
+
+// DELETE /members/providers/:provider
+members.delete('/members/providers/:provider', requireLogIn, async (req, res) => {
+  await req.user.deleteAuth(req.params.provider, db)
+  const auths = await req.user.getAuths(db)
+  res.status(200).json(auths)
 })
 
 // GET /members/messages
@@ -47,19 +60,6 @@ members.get('/members/messages', requireLogIn, async (req, res) => {
 members.get('/members/invited', requireLogIn, async (req, res) => {
   const invited = await req.user.getInvited(db)
   res.status(200).json(invited.map(member => member.privatize ? member.privatize() : member))
-})
-
-// GET /members/auths
-members.get('/members/auths', requireLogIn, async (req, res) => {
-  const auths = await req.user.getAuths(db)
-  res.status(200).json(auths)
-})
-
-// DELETE /members/auths/:provider
-members.delete('/members/auths/:provider', requireLogIn, async (req, res) => {
-  await req.user.deleteAuth(req.params.provider, db)
-  const auths = await req.user.getAuths(db)
-  res.status(200).json(auths)
 })
 
 // GET /members/:id


### PR DESCRIPTION
There's a principle in REST API design that says that your endpoints should be nouns, and then you can rely on verbs to decide what to do with those nouns. I don't know if that makes sense throughout the entire API that we have here, but it certainly makes sense here. This organizes the endpoints that deal with OAuth 2.0 tokens under a /members/providers endpoint, with a POST to create a new one, a GET to fetch the array, and a DELETE /members/providers/:provider to delete a specific one.