### PR TITLE
Expand permissions info

### DIFF
--- a/routes/pages.js
+++ b/routes/pages.js
@@ -101,7 +101,11 @@ pages.patch('/pages/*/unhide', requireLogIn, loadPage, async (req, res) => {
 // GET /pages/*
 pages.get('/pages/*', optionalLogIn, loadPage, async (req, res) => {
   const parsed = await parser(req.page.history.getBody(), req.page.path, req.user, db)
-  res.status(200).json({ page: req.page, markup: parsed.html })
+  const read = req.page.checkPermissions(req.user, 4)
+  const write = req.page.checkPermissions(req.user, 6)
+  const code = req.page.permissions
+  req.page.permissions = { read, write, code }
+    res.status(200).json({ page: req.page, markup: parsed.html })
 })
 
 // POST /autocomplete

--- a/routes/pages.spec.js
+++ b/routes/pages.spec.js
@@ -445,13 +445,16 @@ describe('Pages API', () => {
 
   describe('GET /pages/*', () => {
     it('returns 200', async () => {
-      expect.assertions(5)
+      expect.assertions(8)
       const res = await request.get('/pages/test-page')
       const { page, markup } = res.body
       expect(res.status).toEqual(200)
       expect(page.path).toEqual('/test-page')
       expect(page.title).toEqual('Test Page')
       expect(page.history.changes).toHaveLength(1)
+      expect(page.permissions.read).toEqual(true)
+      expect(page.permissions.write).toEqual(false)
+      expect(page.permissions.code).toEqual(774)
       expect(markup).toEqual('<p>This is a test page.</p>\n')
     })
 


### PR DESCRIPTION
Instead of just the number, you now get that number as permissions.code, but you also get permissions.read and permissions.write — booleans that say if the person making the request has read and write permissions, respectively.