### PR TITLE
GET /pages/* - Add query param to parse a previous version

### DIFF
--- a/routes/pages.js
+++ b/routes/pages.js
@@ -100,7 +100,13 @@ pages.patch('/pages/*/unhide', requireLogIn, loadPage, async (req, res) => {
 
 // GET /pages/*
 pages.get('/pages/*', optionalLogIn, loadPage, async (req, res) => {
-  const parsed = await parser(req.page.history.getBody(), req.page.path, req.user, db)
+  let body = req.page.history.getBody()
+  if (req.query && req.query.version) {
+    const matching = req.page.history.changes.filter(change => change.id === parseInt(req.query.version))
+    const version = matching && Array.isArray(matching) && matching.length > 0 ? matching[0] : null
+    if (version && version.content && version.content.body) body = version.content.body
+  }
+  const parsed = await parser(body, req.page.path, req.user, db)
   const read = req.page.checkPermissions(req.user, 4)
   const write = req.page.checkPermissions(req.user, 6)
   const code = req.page.permissions

--- a/routes/pages.spec.js
+++ b/routes/pages.spec.js
@@ -469,6 +469,18 @@ describe('Pages API', () => {
       expect(res.status).toEqual(401)
     })
 
+    it('can return markup for a specific version', async () => {
+      expect.assertions(2)
+      const editor = await Member.load(2, db)
+      const page = await Page.get('/test-page', db)
+      await page.update({ body: 'This is an update.' }, editor, 'Test update #1', db)
+      await page.update({ body: 'This is a second update.' }, editor, 'Test update #2', db)
+      const vids = page.history.changes.map(change => change.id)
+      const res = await request.get(`/pages/test-page?version=${vids[1]}`)
+      expect(vids).toHaveLength(3)
+      expect(res.body.markup).toEqual('<p>This is an update.</p>\n')
+    })
+
     it('returns URLs and readable sizes for files', async () => {
       expect.assertions(4)
       const member = await Member.load('normal@thefifthworld.com', db)


### PR DESCRIPTION
If you provide ?version=X, and X is the ID of a previous version of the page, the markup provided comes from that version, rather than the most recent one.