### PR TITLE
Page.export: Remove page ID from file

### DIFF
--- a/models/page.js
+++ b/models/page.js
@@ -72,7 +72,10 @@ class Page {
     if (copy && copy.owner) delete copy.owner.email
     delete copy.saved
     if (copy && copy.files && Array.isArray(copy.files)) {
-      copy.files.forEach(file => delete file.saved)
+      copy.files.forEach(file => {
+        delete file.saved
+        delete file.page
+      })
     }
     return copy
   }

--- a/models/page.spec.js
+++ b/models/page.spec.js
@@ -214,6 +214,25 @@ describe('Page', () => {
       await testUtils.resetTables(db)
       expect(actual).toEqual(true)
     })
+
+    it('removes page ID from any files', async () => {
+      expect.assertions(1)
+      await testUtils.populateMembers(db)
+      const editor = await Member.load(2, db)
+      const data = {
+        title: 'Test page',
+        body: 'This is a test.',
+        files: { file: testUtils.mockTXT() }
+      }
+      await Page.create(data, editor, 'Initial text', db)
+      const page = await Page.get('/test-page', db)
+      const ex = page.export()
+      const actual = ex && ex.files && Array.isArray(ex.files) && ex.files.length > 0
+        ? ex.files.map(file => file.page === undefined).reduce((acc, curr) => acc && curr, true)
+        : false
+      await testUtils.resetTables(db)
+      expect(actual).toEqual(true)
+    })
   })
 
   describe('save', () => {


### PR DESCRIPTION
When exported, the files are in the context of the page object, making the page ID redundant.