### PR TITLE
Page.export: Clean up lineage

### DIFF
--- a/models/page.js
+++ b/models/page.js
@@ -60,25 +60,12 @@ class Page {
   }
 
   /**
-   * Create an object from the page suitable for export through the API.
-   * @returns {object} - An object from the page suitable for export through
-   *   the API.
+   * Prepares the Page object for export through the API.
+   * @returns {object} - An object representation of this Page instance ready
+   *   to be delivered through the API.
    */
 
-  export () {
-    const copy = JSON.parse(JSON.stringify(this))
-    if (copy && copy.history) copy.history = copy.history.changes
-    if (copy && copy.likes) copy.likes = copy.likes.ids
-    if (copy && copy.owner) delete copy.owner.email
-    delete copy.saved
-    if (copy && copy.files && Array.isArray(copy.files)) {
-      copy.files.forEach(file => {
-        delete file.saved
-        delete file.page
-      })
-    }
-    return copy
-  }
+  export () { return Page.export(this) }
 
   /**
    * Insert a record for this page into the database.
@@ -663,6 +650,41 @@ class Page {
       }
       return desc.trim()
     }
+  }
+
+  /**
+   * Prepares a Page object for export through the API.
+   * @returns {object} - An object from the page suitable for export through
+   *   the API.
+   */
+
+  static export (obj) {
+    const copy = JSON.parse(JSON.stringify(obj))
+    if (copy && copy.history && copy.history.changes) copy.history = copy.history.changes
+    if (copy && copy.likes && copy.likes.ids) copy.likes = copy.likes.ids
+    if (copy && copy.owner) delete copy.owner.email
+    delete copy.saved
+
+    // Clean up files
+    if (copy && copy.files && Array.isArray(copy.files)) {
+      copy.files.forEach(file => {
+        delete file.saved
+        delete file.page
+      })
+    }
+
+    // Clean up lineage
+    if (copy && copy.lineage && Array.isArray(copy.lineage)) {
+      copy.lineage = copy.lineage.map(ancestor => {
+        delete ancestor.history
+        delete ancestor.likes
+        delete ancestor.files
+        delete ancestor.lineage
+        return Page.export(ancestor)
+      })
+    }
+
+    return copy
   }
 }
 

--- a/models/page.spec.js
+++ b/models/page.spec.js
@@ -233,6 +233,48 @@ describe('Page', () => {
       await testUtils.resetTables(db)
       expect(actual).toEqual(true)
     })
+
+    it('applies the same rules to pages in its lineage', async () => {
+      expect.assertions(3)
+      await testUtils.populateMembers(db)
+      const editor = await Member.load(2, db)
+      const root = await Page.create({ title: 'Root', body: 'This is the root page.' }, editor, 'Initial text', db)
+      await Page.create({ title: 'Child Page', body: 'This is a child page.', parent: root.id }, editor, 'Initial text', db)
+      const page = await Page.get('/root/child-page', db)
+      const actual = page.export()
+      await testUtils.resetTables(db)
+      expect(actual.lineage).toHaveLength(1)
+      expect(actual.lineage[0].saved).not.toBeDefined()
+      expect(actual.lineage[0].owner.email).not.toBeDefined()
+    })
+
+    it('removes history, likes, and files from pages in its lineage', async () => {
+      expect.assertions(4)
+      await testUtils.populateMembers(db)
+      const editor = await Member.load(2, db)
+      const root = await Page.create({ title: 'Root', body: 'This is the root page.' }, editor, 'Initial text', db)
+      await Page.create({ title: 'Child Page', body: 'This is a child page.', parent: root.id }, editor, 'Initial text', db)
+      const page = await Page.get('/root/child-page', db)
+      const actual = page.export()
+      await testUtils.resetTables(db)
+      expect(actual.lineage).toHaveLength(1)
+      expect(actual.lineage[0].history).not.toBeDefined()
+      expect(actual.lineage[0].files).not.toBeDefined()
+      expect(actual.lineage[0].likes).not.toBeDefined()
+    })
+
+    it('removes lineage from pages in its lineage', async () => {
+      expect.assertions(2)
+      await testUtils.populateMembers(db)
+      const editor = await Member.load(2, db)
+      const root = await Page.create({ title: 'Root', body: 'This is the root page.' }, editor, 'Initial text', db)
+      await Page.create({ title: 'Child Page', body: 'This is a child page.', parent: root.id }, editor, 'Initial text', db)
+      const page = await Page.get('/root/child-page', db)
+      const actual = page.export()
+      await testUtils.resetTables(db)
+      expect(actual.lineage).toHaveLength(1)
+      expect(actual.lineage[0].lineage).not.toBeDefined()
+    })
   })
 
   describe('save', () => {


### PR DESCRIPTION
Apply exporting rules to pages in lineage. Cut them down to "mini-pages," without history, likes, or files. And don't include their own lineages — that sort of recursion can make for huge payloads and it's ridiculously redundant. If you need more on an ancestor, just make a second API call for more details. The lineage array gives you everything you need to do that.