### PR TITLE
Don't render anything inside of {{Template}}

### DIFF
--- a/parser/index.js
+++ b/parser/index.js
@@ -65,7 +65,7 @@ const parser = async (str, path, member, db) => {
   const { stripped, tagHandler } = TagHandler.parse(blocked)
 
   // Render templates
-  let templated = stripped
+  let templated = stripped.replace(/{{Template}}(\r|\n|.)*?{{\/Template}}/gm, '')
   const templates = await TemplateHandler.parse(stripped, { page: Page, fileHandler: FileHandler })
   await templates.render({ path, member }, db)
   for (const key of Object.keys(templates.instances)) {

--- a/parser/index.spec.js
+++ b/parser/index.spec.js
@@ -78,4 +78,10 @@ describe('Parser', () => {
     const actual = await parser('```\r\n{{Artists}}\r\n```\n\nThis is outside of the code block.', null, null, db)
     expect(actual.html).toEqual('<pre><code>\r\n{{Artists}}\r\n</code></pre>\n<p>This is outside of the code block.</p>\n')
   })
+
+  it('doesn\'t render anything inside of {{Template}}', async () => {
+    expect.assertions(1)
+    const actual = await parser('{{Template}}\r\nThis is inside of a template block.\r\n{{/Template}}\r\n\r\nThis is outside of the template block.', null, null, db)
+    expect(actual.html).toEqual('<p>This is outside of the template block.</p>\n')
+  })
 })


### PR DESCRIPTION
The {{Template}} tag specifies what's used when the page is used as a template, but it shouldn't be rendered when you actually visit that page. This allows us to pack the template and its documentation into one page (inspired by MediaWiki).