### PR TITLE
GET /page/* - Return structured data

### DIFF
--- a/docs/ref/pages/get-page.html
+++ b/docs/ref/pages/get-page.html
@@ -98,6 +98,11 @@ Host: api.thefifthworld.com</code>
             <td><code>string</code></td>
             <td>This property provides the rendered HTML for the current body of the page.</td>
           </tr>
+          <tr>
+            <td><code>data</code></td>
+            <td><code>object</code></td>
+            <td>This property provides the structured data provided in the current state of the page.</td>
+          </tr>
         </tbody>
       </table>
       <table>
@@ -411,7 +416,8 @@ Host: api.thefifthworld.com</code>
       }
     ]
   },
-  "markup": "&lt;aside&gt;We only have a &lt;strong&gt;stub&lt;/strong&gt; for this article right now. Help us out by fleshing it out further.&lt;/aside&gt;\n&lt;p&gt;&lt;strong&gt;Mammals&lt;/strong&gt; give birth to live young and produce milk to nurse them. As mammals ourselves, we &lt;a href=\"/new?title=Homo%20sapiens\" class=\"isNew\"&gt;humans&lt;/a&gt; often conflate our class with the &lt;a href=\"/animalia\" title=\"Animal\"&gt;animal kingdom&lt;/a&gt; itself, even though we compromise only a fairly small class among &lt;a href=\"/animalia/chordata\" title=\"Vertebrate\"&gt;vertebrates&lt;/a&gt;, who themselves make up only a small part of the kingdom.&lt;/p&gt;\n"
+  "markup": "&lt;aside&gt;We only have a &lt;strong&gt;stub&lt;/strong&gt; for this article right now. Help us out by fleshing it out further.&lt;/aside&gt;\n&lt;p&gt;&lt;strong&gt;Mammals&lt;/strong&gt; give birth to live young and produce milk to nurse them. As mammals ourselves, we &lt;a href=\"/new?title=Homo%20sapiens\" class=\"isNew\"&gt;humans&lt;/a&gt; often conflate our class with the &lt;a href=\"/animalia\" title=\"Animal\"&gt;animal kingdom&lt;/a&gt; itself, even though we compromise only a fairly small class among &lt;a href=\"/animalia/chordata\" title=\"Vertebrate\"&gt;vertebrates&lt;/a&gt;, who themselves make up only a small part of the kingdom.&lt;/p&gt;\n",
+  "data": {}
 }</code>
       </figure>
     </main>

--- a/routes/pages.js
+++ b/routes/pages.js
@@ -148,11 +148,19 @@ pages.get('/pages/*', optionalLogIn, loadPage, async (req, res) => {
     if (version && version.content && version.content.body) body = version.content.body
   }
   const parsed = await parser(body, req.page.path, req.user, db)
+
   const read = req.page.checkPermissions(req.user, 4)
   const write = req.page.checkPermissions(req.user, 6)
   const code = req.page.permissions
   req.page.permissions = { read, write, code }
-  res.status(200).json({ page: req.page.export(), markup: parsed.html })
+
+  let data = {}
+  try {
+    const curr = req.page.history.getContent()
+    data = curr && curr.data ? JSON.parse(curr.data) : {}
+  } catch (err) {}
+
+  res.status(200).json({ page: req.page.export(), markup: parsed.html, data })
 })
 
 // GET /templates

--- a/routes/pages.spec.js
+++ b/routes/pages.spec.js
@@ -723,9 +723,9 @@ describe('Pages API', () => {
 
   describe('GET /pages/*', () => {
     it('returns 200', async () => {
-      expect.assertions(8)
+      expect.assertions(9)
       const res = await request.get('/pages/test-page')
-      const { page, markup } = res.body
+      const { page, markup, data } = res.body
       expect(res.status).toEqual(200)
       expect(page.path).toEqual('/test-page')
       expect(page.title).toEqual('Test Page')
@@ -734,6 +734,7 @@ describe('Pages API', () => {
       expect(page.permissions.write).toEqual(false)
       expect(page.permissions.code).toEqual(774)
       expect(markup).toEqual('<p>This is a test page.</p>\n')
+      expect(data).toEqual({ test: 42 })
     })
 
     it('returns 401 if you don\'t have permission', async () => {

--- a/test-utils.js
+++ b/test-utils.js
@@ -80,7 +80,7 @@ const populateMembers = async (db) => {
 const createTestPage = async (Page, Member, db) => {
   await populateMembers(db)
   const editor = await Member.load(2, db)
-  const data = { title: 'Test Page', body: 'This is a test page.' }
+  const data = { title: 'Test Page', body: 'This is a test page.', data: '{ "test": 42 }' }
   return Page.create(data, editor, 'Initial text', db)
 }
 


### PR DESCRIPTION
Use the `data` property to store structured data (JSON) associated with a page. Perfect for storing things like data on communities, people, and places for things like Discord bots or community creation tools.