### PR TITLE
Fix parser bug

### DIFF
--- a/models/taghandler.js
+++ b/models/taghandler.js
@@ -76,17 +76,17 @@ class TagHandler {
   static parse (str) {
     const tagHandler = new TagHandler()
     let stripped = str
-    const matches = str.match(/\[\[(.*?):(.*?)\]\]/gm)
+    const matches = str.match(/\[\[(.*?)\]\]/gm)
     if (matches) {
       matches.forEach(match => {
-        stripped = stripped.replace(match, '')
-        const pair = match.substr(2, match.length - 4).split(':').map(el => el.trim())
-        if (pair && pair.length > 1) {
-          tagHandler.add(...pair)
+        const submatch = match.substr(2, match.length - 4).match(/^(.*?):(.*?)$/)
+        if (submatch && submatch.length > 2) {
+          stripped = stripped.replace(match, '')
+          tagHandler.add(submatch[1].trim(), submatch[2].trim())
         }
       })
     }
-    stripped = stripped.replace(/ +/gm, ' ')
+    stripped = stripped.replace(/ +/gm, ' ').trim()
     return { stripped, tagHandler }
   }
 

--- a/models/taghandler.spec.js
+++ b/models/taghandler.spec.js
@@ -141,6 +141,11 @@ describe('TagHandler', () => {
       const actual = TagHandler.parse('This [[Hello:World]] is [[Hello : Test]] text [[Tag: 1]] outside of tags.\n\nAnd here is a [[Test:true]] second paragraph.')
       expect(actual.stripped).toEqual('This is text outside of tags.\n\nAnd here is a second paragraph.')
     })
+
+    it('doesn\'t get greedy', async () => {
+      const actual = TagHandler.parse('[[Link]] has this to say: [[Hello]]! [[Tag:Test]]')
+      expect(actual.stripped).toEqual('[[Link]] has this to say: [[Hello]]!')
+    })
   })
 
   describe('load', () => {


### PR DESCRIPTION
Let's say you've got wiki text that involves links and at least one colon, like, "[[Link]] has something to say: [[Hello]]!" Well, the old regex we were using to find tags (which have the form [[Tag:Value]]) would read that whole sentence (sans the exclamation point at the very end) as one tag. This fixes that (and throws in a unit test to make sure it doesn't happen again).