### PR TITLE
{{ListPages}} special template takes an order attribute

### DIFF
--- a/models/templateHandler.js
+++ b/models/templateHandler.js
@@ -252,6 +252,10 @@ class TemplateHandler {
    *   criteria. (Default: `and`)
    * @param instance.limit {?number} - The maximum number of results to return.
    *   (Default: 10)
+   * @param instance.order {?string=} - How the pages should be ordered. Valid
+   *   options are `alphabetical`, `reverse alphabetical`, `first created`,
+   *   `last created`, `oldest update`, and `most recent update`
+   *   (Default: `alphabetical`).
    * @param options {object} - Options necessary for rendering templates.
    * @param options.member {Member} - The member requesting this rendering.
    * @param db {Pool} - The database connection.
@@ -273,6 +277,7 @@ class TemplateHandler {
     if (instance.type) query.type = instance.type
     if (instance.logic) query.logic = instance.logic
     if (instance.limit) query.limit = parseInt(instance.limit)
+    if (instance.order) query.order = instance.order
 
     if (instance.tags) {
       const split = instance.tags.split(';').map(pair => pair.trim().split(':').map(el => el.trim()))

--- a/models/templateHandler.spec.js
+++ b/models/templateHandler.spec.js
@@ -524,6 +524,34 @@ describe('TemplateHandler', () => {
       await testUtils.resetTables(db)
       expect(actual.markup).toEqual('<ul><li><a href="/test-page/child-page">Child Page</a></li></ul>')
     })
+
+    it('defaults to alphabetical order', async () => {
+      expect.assertions(1)
+      await testUtils.createTestPage(Page, Member, db)
+      const member = await Member.load(2, db)
+      await Page.create({ title: 'Test Page XYZ', body: 'This is also a test page.' }, member, 'Initial text', db)
+      await Page.create({ title: 'Test Page ABC', body: 'This is also a test page.' }, member, 'Initial text', db)
+      await Page.create({ title: 'Something Else', body: 'This is also a test page.' }, member, 'Initial text', db)
+      const actual = { name: 'ListPages', title: 'Test Page' }
+      const handler = new TemplateHandler({ page: Page })
+      await handler.renderListPages(actual, { member }, db)
+      await testUtils.resetTables(db)
+      expect(actual.markup).toEqual('<ul><li><a href="/test-page">Test Page</a></li><li><a href="/test-page-abc">Test Page ABC</a></li><li><a href="/test-page-xyz">Test Page XYZ</a></li></ul>')
+    })
+
+    it('uses order given', async () => {
+      expect.assertions(1)
+      await testUtils.createTestPage(Page, Member, db)
+      const member = await Member.load(2, db)
+      await Page.create({ title: 'Test Page XYZ', body: 'This is also a test page.' }, member, 'Initial text', db)
+      await Page.create({ title: 'Test Page ABC', body: 'This is also a test page.' }, member, 'Initial text', db)
+      await Page.create({ title: 'Something Else', body: 'This is also a test page.' }, member, 'Initial text', db)
+      const actual = { name: 'ListPages', title: 'Test Page', order: 'reverse alphabetical' }
+      const handler = new TemplateHandler({ page: Page })
+      await handler.renderListPages(actual, { member }, db)
+      await testUtils.resetTables(db)
+      expect(actual.markup).toEqual('<ul><li><a href="/test-page-xyz">Test Page XYZ</a></li><li><a href="/test-page-abc">Test Page ABC</a></li><li><a href="/test-page">Test Page</a></li></ul>')
+    })
   })
 
   describe('renderListPagesUsingTemplate', () => {


### PR DESCRIPTION
Choose between `alphabetical`, `reverse alphabetical`, `first created`, `last created`, `oldest update`, and `most recent update`. Defaults to `alphabetical`.